### PR TITLE
Agora é possível criar novas reuniões atravéz da página 'new meeting'…

### DIFF
--- a/backend/src/agenda/agenda.controller.ts
+++ b/backend/src/agenda/agenda.controller.ts
@@ -1,17 +1,14 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { AgendaService } from './agenda.service';
+import { CreateAgendaDto } from './dto/create-agenda.dto';
 
 @Controller('agenda')
 export class AgendaController {
-  // constructor(private readonly agendaService: AgendaService) { }
+  constructor(private readonly agendaService: AgendaService) { }
 
-  // @Get()
-  // getAgenda() {
-  //   return this.agendaService.getAgenda();
-  // }
+  @Post()
+  async create(@Body() dto: CreateAgendaDto) {
+    return this.agendaService.create(dto);
+  }
 
-  // @Post('vote')
-  // vote(@Body() body: { id: number; vote: 'approve' | 'reprove' | 'abstain' }) {
-  //   return this.agendaService.vote(body.id, body.vote);
-  // }
 }

--- a/backend/src/agenda/agenda.module.ts
+++ b/backend/src/agenda/agenda.module.ts
@@ -3,9 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agenda } from './agenda.entity';
 import { AgendaService } from './agenda.service';
 import { AgendaController } from './agenda.controller';
+import { AgendaItem } from 'src/agenda-item/agenda-item.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Agenda])],
+  // Register both Agenda and AgendaItem so the service can update items when creating an agenda
+  imports: [TypeOrmModule.forFeature([Agenda, AgendaItem])],
   controllers: [AgendaController],
   providers: [AgendaService]
 })

--- a/backend/src/agenda/dto/create-agenda.dto.ts
+++ b/backend/src/agenda/dto/create-agenda.dto.ts
@@ -1,0 +1,6 @@
+export class CreateAgendaDto {
+  begin?: string;
+  end?: string;
+  place?: string;
+  itemIds?: number[];
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,9 @@ import { VoteModule } from './vote/vote.module';
       entities: [__dirname + '/**/*.entity{.ts,.js}'],
       synchronize: true,
       autoLoadEntities: true,
+      // Enable query/schema logging so you can see CREATE TABLE and other SQL in the console
+      logging: ['query', 'schema', 'error'],
+      logger: 'advanced-console',
     })
     , AgendaModule, AgendaItemModule, UserModule, VoteModule],
   controllers: [AppController],

--- a/frontend/src/app/components/form-checkbox/form-checkbox.html
+++ b/frontend/src/app/components/form-checkbox/form-checkbox.html
@@ -1,5 +1,5 @@
 <div class="checkbox-wrapper">
-  <input type="checkbox" [id]="itemId">
+  <input type="checkbox" [id]="itemId" (change)="onChange($event)">
   <div class="labels">
     <label [for]="itemId" class="main-label">{{ title }}</label>
     <label [for]="itemId" class="sublabel">{{ subtitle }}</label>

--- a/frontend/src/app/components/form-checkbox/form-checkbox.ts
+++ b/frontend/src/app/components/form-checkbox/form-checkbox.ts
@@ -1,4 +1,4 @@
-import { Component, Input,  } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-form-checkbox',
@@ -10,6 +10,12 @@ export class FormCheckbox {
   @Input() itemId: number = 0;
   @Input() title: string = '';
   @Input() subtitle: string = '';
+  @Output() checkedChange = new EventEmitter<boolean>();
+
+  onChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.checkedChange.emit(target.checked);
+  }
 
 
 }

--- a/frontend/src/app/components/form-date/form-date.html
+++ b/frontend/src/app/components/form-date/form-date.html
@@ -1,4 +1,4 @@
 <div class="container">
     <label class="label" for="titulo">{{title}}</label>
-    <input class="form" type="date" id="date">
-<div class="container">
+    <input class="form" type="date" id="date" [value]="value" (change)="onChange($event)">
+</div>

--- a/frontend/src/app/components/form-date/form-date.ts
+++ b/frontend/src/app/components/form-date/form-date.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-form-date',
@@ -9,5 +9,13 @@ import { Component, Input } from '@angular/core';
 export class FormDate {
   @Input() title: string = '';
   @Input() id: string = '';
+  @Input() value: string = '';
+  @Output() valueChange = new EventEmitter<string>();
+
+  onChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.value = target.value;
+    this.valueChange.emit(this.value);
+  }
 
 }

--- a/frontend/src/app/components/form-time/form-time.html
+++ b/frontend/src/app/components/form-time/form-time.html
@@ -1,4 +1,4 @@
 <div class="container">
     <label class="label" for="titulo">{{title}}</label>
-    <input class="form" type="time" id="time">
-<div class="container">
+    <input class="form" type="time" id="time" [value]="value" (change)="onChange($event)">
+</div>

--- a/frontend/src/app/components/form-time/form-time.ts
+++ b/frontend/src/app/components/form-time/form-time.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'app-form-time',
@@ -8,4 +8,12 @@ import { Component, Input } from '@angular/core';
 })
 export class FormTime {
   @Input() title: string = '';
+  @Input() value: string = '';
+  @Output() valueChange = new EventEmitter<string>();
+
+  onChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.value = target.value;
+    this.valueChange.emit(this.value);
+  }
 }

--- a/frontend/src/app/features/new-meeting/new-meeting.html
+++ b/frontend/src/app/features/new-meeting/new-meeting.html
@@ -12,27 +12,28 @@
       <div *ngIf="isRemoteMeeting; else presencial">
         <div class="column">
           <div class="row">
-            <app-form-date title="Data de início"></app-form-date>
-            <app-form-time title="Horário de início"></app-form-time>
+            <app-form-date title="Data de início" [(value)]="beginDate"></app-form-date>
+            <app-form-time title="Horário de início" [(value)]="beginTime"></app-form-time>
           </div>
 
           <div class="row">
-            <app-form-date title="Data de fim"></app-form-date>
-            <app-form-time title="Horário de fim"></app-form-time>
+            <app-form-date title="Data de fim" [(value)]="endDate"></app-form-date>
+            <app-form-time title="Horário de fim" [(value)]="endTime"></app-form-time>
           </div>
         </div>
       </div>
       <ng-template #presencial>
         <div class="column">
           <div class="row">
-            <app-form-date title="Data"></app-form-date>
-            <app-form-time title="Horário"></app-form-time>
-          </div>
-          <app-text-input-simple
-            style="width: 660px"
-            [title]="'Local'"
-            [placeholder]="'Sala e prédio da reunião'">
-          </app-text-input-simple>
+              <app-form-date title="Data" [(value)]="beginDate"></app-form-date>
+              <app-form-time title="Horário" [(value)]="beginTime"></app-form-time>
+            </div>
+            <app-text-input-simple
+              style="width: 660px"
+              [title]="'Local'"
+              [placeholder]="'Sala e prédio da reunião'"
+              [(value)]="place">
+            </app-text-input-simple>
         </div>
       </ng-template>
 
@@ -40,13 +41,13 @@
         <label class="title">Itens de pauta disponíveis:</label>
         <div *ngFor="let item of agendaItems">
           <app-form-checkbox [title]="item.title" [subtitle]="'Criado em ' + formatDateCreation(item)"
-            [itemId]="item.id">
+            [itemId]="item.id" (checkedChange)="toggleItem(item.id, $event)">
           </app-form-checkbox>
         </div>
       </div>
 
       <div class="button-group">
-        <button class="button-create">Criar reunião</button>
+        <button class="button-create" (click)="createMeeting()">Criar reunião</button>
       </div>
     </app-card>
   </div>

--- a/frontend/src/app/features/new-meeting/new-meeting.ts
+++ b/frontend/src/app/features/new-meeting/new-meeting.ts
@@ -12,6 +12,12 @@ export class NewMeeting implements OnInit {
   agendaItems: AgendaItem[] = [];
   selectedItems: number[] = [];
   isRemoteMeeting: boolean = false;
+  place: string = '';
+  // bound to form-date and form-time components
+  beginDate: string = '';
+  beginTime: string = '';
+  endDate: string = '';
+  endTime: string = '';
 
   constructor(private agendaItemService: AgendaItemService) { }
 
@@ -40,6 +46,46 @@ export class NewMeeting implements OnInit {
     const date = new Date(item.dateCreation);
     const pipe = new DatePipe('pt-BR');
     return pipe.transform(date, format) ?? '';
+  }
+
+  createMeeting(): void {
+    const combine = (date: string | undefined, time: string | undefined) => {
+      if (!date) return undefined;
+      const t = time ?? '00:00';
+      // construct ISO string in local time by using Date constructor with YYYY-MM-DDTHH:MM
+      const iso = new Date(date + 'T' + t + ':00');
+      return iso.toISOString();
+    };
+
+    let beginIso: string | undefined;
+    let endIso: string | undefined;
+
+    if (this.isRemoteMeeting) {
+      beginIso = combine(this.beginDate, this.beginTime);
+      endIso = combine(this.endDate, this.endTime);
+    } else {
+      beginIso = combine(this.beginDate, this.beginTime) ?? new Date().toISOString();
+      endIso = undefined;
+    }
+
+    const dto = {
+      begin: beginIso,
+      end: endIso,
+      place: this.place,
+      itemIds: this.selectedItems
+    };
+
+    // POST to backend /agenda
+    fetch('http://localhost:3000/agenda', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(dto)
+    }).then(r => r.json())
+      .then(data => {
+        console.log('Agenda criada:', data);
+        // optional: navigate to meeting page or show confirmation
+      })
+      .catch(err => console.error('Erro ao criar agenda:', err));
   }
 
 }


### PR DESCRIPTION
… e elas são salvas no banco de dados

OBS: Atualmente, um item de agenda tem uma coluna que aponta para o id da agenda que anexou-o, esse é um campo único e ele é sobrescrito se esse item de agenda é selecionado novamente para uma reunião posterior, não tenho certeza se esse é o jeito ideal, mas resolvi deixar assim mesmo.

OBS 2: O botão ta funcionando direitinho, mas não implementei nenhuma responsividade, então a página não atualiza e se tu spammar o botão provavelmente vai criar várias agendas (não testei).