### PR TITLE
Fix: Pacote para rodar front e back com apenas um comando

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ cd VotaINF
 
 ## Dependências
 
+Para instalar as dependências de projeto, rode:
+
+```
+npm install
+```
+
 Para instalar as dependências do back-end, rode:
 
 ```
@@ -62,17 +68,28 @@ npm install
 
 ## Executar
 
-Para rodar o back-end, vá até o diretório correspondente e rode:
+Para rodar o front e o back-end no mesmo terminal, rode na raiz do projeto:
+```
+npm start
+```
+
+### Apenas back-end
+
+Para rodar o back-end isoladamente, vá até o diretório correspondente e rode:
 
 ```
+cd backend
 npm run start
 ```
 
 O servidor rodará em: `http://localhost:3000/`.
 
-Para rodar o front-end, vá até o diretório correspondente e rode:
+### Apenas front-end
+
+Para rodar o front-end isoladamente, vá até o diretório correspondente e rode:
 
 ```
+cd frontend
 ng serve
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,5 +2,14 @@
   "dependencies": {
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2"
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1"
+  },
+  "scripts": {
+    "start": "concurrently \"npm run start:server\" \"npm run start:client\"",
+    "start:server": "cd backend && npm start",
+    "start:client": "cd frontend && npm start"
   }
+
 }


### PR DESCRIPTION
Justificativa: muitas vezes queria matar o processo e rodar novamente, pra reabrir as portas. Precisava abrir dois processos no terminal e rodar individualmente o front e o back. Agora rodo apenas um comando em um terminal.

# Commit
* Instala dependência `concurrently`, para rodar processos diferentes no terminal com apenas um comando npm

# Como Testar

Na raiz do projeto, instale a nova dependência:
```
npm install
```

O comando para executar o front-end e o back-end é apenas:
```
npm start
```

<img width="671" height="413" alt="image" src="https://github.com/user-attachments/assets/5c30d1a3-1745-4f03-84e3-2cf826098b8c" />
